### PR TITLE
fix div for empty reports

### DIFF
--- a/index.ejs
+++ b/index.ejs
@@ -219,11 +219,12 @@
 		</table>
 
 		<%if (issues.length > 0) { %>
-
 		<canvas id="vulnerabilitiesPieChart" width="200" height="200"></canvas>
+		<% } %>
 	</div>
 
 	<div class=detail>
+		<%if (issues.length > 0) { %>
 		<h2>Detail of the Detected Vulnerabilities</h2>
 		<table>
 			<thead>


### PR DESCRIPTION
The div were not correctly open/closed for empty reports. 
If no vuln: 
- vulnerabilitiesPieChart shouln't be displayed 
- the `summup` div should close before opening the `detail` div
