### PR TITLE
Remove trailing slash

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,8 @@ const data = {
   allBugs: (argv.allbugs == 'true'),
   fixMissingRule: (argv.fixMissingRule == 'true'),
   noSecurityHotspot: (argv.noSecurityHotspot == 'true'),
-  sonarBaseURL: argv.sonarurl,
+  // sonar URL without trailing /
+  sonarBaseURL: argv.sonarurl.replace(/\/$/, ""),
   sonarOrganization: argv.sonarorganization,
   rules: [],
   issues: []

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sonar-report",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonar-report",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "main": "index.js",
   "author": "SopraSteria",
   "bin": {


### PR DESCRIPTION
when the sonar_url ends with a /, we get: 
```
SyntaxError: Unexpected token < in JSON at position 0
    at JSON.parse (<anonymous>)
    at Object.<anonymous> (D:\product\defectDojo\sonar-report-github2\index.js:161:23)
    at Module._compile (internal/modules/cjs/loader.js:776:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:787:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:829:12)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:622:3)
```

this removes the trailing / to avoid this issue

