### PR TITLE
Even for hotspots, description must not be empty, fix issue #68

### DIFF
--- a/index.js
+++ b/index.js
@@ -313,7 +313,7 @@ function logError(context, error){
                 // Take only filename with path, without project name
                 component: hotspot.component.split(':').pop(),
                 line: hotspot.line,
-                description: "",
+                description: hotspot.key + " " + hotspot.project,
                 message: hotspot.message,
                 key: hotspot.key
               };


### PR DESCRIPTION
Original issue description :
A tool such as DefectDojo expects a non-empty string as vulnerability description, otherwise the report cannot be imported.
But for now, in case of hotspot, description value for the report is set to "". So we must at least provide a constant string such as "Hotspot", or even better: a string that makes sense for the current hotspot. The problem is that, except the hotspot "message" field already used to fill "message" field in report, there is no real good candidate for "description" field in report.