### PR TITLE
fix: added filter by pull request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+sonar-report.html

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sonar-report",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonar-report",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "main": "index.js",
   "author": "SopraSteria",
   "bin": {


### PR DESCRIPTION
- Added new option --pullrequest to be used instead of --branch when you want to have a report on a pull request analysis instead of a branch analysis.
- Fixed an issue when searching for hotspots: we were not filtering with branch nor pullrequest.
- Fixed indentation.