### PR TITLE
Optimize rules performance

### DIFF
--- a/index.ejs
+++ b/index.ejs
@@ -266,14 +266,14 @@
 				</tr>
 			</thead>
 			<tbody>
-				<% for(var i = 0; i < rules.length; i++) { %>
+				<% for (const [ruleKey, rule] of rules) { %>
 				<tr>
 					<td><a
-							href="https://next.sonarqube.com/sonarqube/coding_rules#rule_key=<%= rules[i].key %>"><%= rules[i].key %></a>
+							href="https://next.sonarqube.com/sonarqube/coding_rules#rule_key=<%= ruleKey %>"><%= ruleKey %></a>
 					</td>
 					<td>
 						<details>
-							<%- rules[i].htmlDesc %>
+							<%- rule.htmlDesc %>
 						</details>
 					</td>
 				</tr>


### PR DESCRIPTION
Retrieve only required rule attributes from Sonar.
Speed up issue rule lookup by storing rules in a Map by rule key.
Needed to be able to use this at all on larger projects.