### PR TITLE
No rules in report flag

### DIFF
--- a/index.ejs
+++ b/index.ejs
@@ -257,6 +257,7 @@
 
 		<% } %>
 
+		<%if (!noRulesInReport) { %>
 		<h3>Known Security Rules</h3>
 		<table style="table-layout: fixed; word-wrap: break-word">
 			<thead>
@@ -280,6 +281,7 @@
 				<% } %>
 			</tbody>
 		</table>
+		<% } %>
 	</div>
 
 	<%if (issues.length > 0) { %>

--- a/index.js
+++ b/index.js
@@ -63,6 +63,9 @@ DESCRIPTION
     --noSecurityHotspot
         Set this flag for old versions of sonarQube without security hotspots (<7.3?). Default is false
 
+    --noRulesInReport
+        Set this flag to omit "Known Security Rules" section from report. Default is false
+
     --help
         display this help message`);
   process.exit();
@@ -100,6 +103,7 @@ function logError(context, error){
     allBugs: (argv.allbugs == 'true'),
     fixMissingRule: (argv.fixMissingRule == 'true'),
     noSecurityHotspot: (argv.noSecurityHotspot == 'true'),
+    noRulesInReport: (argv.noRulesInReport == 'true'),
     // sonar URL without trailing /
     sonarBaseURL: argv.sonarurl.replace(/\/$/, ""),
     sonarOrganization: argv.sonarorganization,


### PR DESCRIPTION
Introduce flag --noRulesInReport to omit Known Security Rules section from report.