### PR TITLE
Link issues to Sonar flag

### DIFF
--- a/index.ejs
+++ b/index.ejs
@@ -249,7 +249,7 @@
 					<td><%= issues[i].description %></td>
 					<td><%= issues[i].message %></td>
 					<td style="display:none;"><%= issues[i].key %></td>
-					<td><%= issues[i].status %></td>
+					<td><%- issues[i].link(issues[i].status) %></td>
 				</tr>
 				<% } %>
 			</tbody>

--- a/index.js
+++ b/index.js
@@ -98,12 +98,12 @@ function logError(context, error){
 
 const issueLink = argv.linkIssues == 'true' ?
     (data, issue) =>
-        c => `<a href=\"${data.sonarBaseURL}/project/issues?id=${encodeURIComponent(data.sonarComponent)}&issues=${encodeURIComponent(issue.key)}&open=${encodeURIComponent(issue.key)}\">${c}</a>` :
+        c => `<a href="${data.sonarBaseURL}/project/issues?${data.branch ? 'branch=' + encodeURIComponent(data.branch) + '&': ''}id=${encodeURIComponent(data.sonarComponent)}&issues=${encodeURIComponent(issue.key)}&open=${encodeURIComponent(issue.key)}">${c}</a>` :
     (data, issue) => c => c;
 
 const hotspotLink = argv.linkIssues == 'true' ?
     (data, hotspot) =>
-        c => `<a href=\"${data.sonarBaseURL}/security_hotspots?id=${encodeURIComponent(data.sonarComponent)}&hotspots=${encodeURIComponent(hotspot.key)}\">${c}</a>` :
+        c => `<a href="${data.sonarBaseURL}/security_hotspots?${data.branch ? 'branch=' + encodeURIComponent(data.branch) + '&': ''}id=${encodeURIComponent(data.sonarComponent)}&hotspots=${encodeURIComponent(hotspot.key)}">${c}</a>` :
     (data, hotspot) => c => c;
 
 (async () => {
@@ -293,6 +293,8 @@ const hotspotLink = argv.linkIssues == 'true' ?
           logError("getting quality gate status", error);
           return null;
       }
+  } else {
+      data.qualityGateStatus = false;
   }
 
   {


### PR DESCRIPTION
Introduce --linkIssues flag to create links to Sonar from reported issues.
This is needed to be able to easily navigate to the specific issues from report.

(cherry picked from commit 364925d0811887f92719ded77703d31484bc05e5)