### PR TITLE
breaking changes.

### DIFF
--- a/index.ejs
+++ b/index.ejs
@@ -42,7 +42,7 @@
 			<dt>Delta analysis</dt>
 			<dd><%= deltaAnalysis %></dd>
 
-			<%if (sinceLeakPeriod) { %>
+			<%if (previousPeriod) { %>
 
 			<dt>Reference period </dt>
 			<dd><%= previousPeriod %></dd>
@@ -147,7 +147,7 @@
 
 		<% } %>
 
-		<%if (!noRulesInReport) { %>
+		<%if (!rulesInReport) { %>
 		<h3>Known Security Rules</h3>
 		<table class="rulestable">
 			<thead>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "sonar-report",
-  "version": "2.5.0",
+  "version": "2.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sonar-report",
-      "version": "2.5.0",
+      "version": "2.7.0",
       "dependencies": {
+        "commander": "^9.4.0",
         "ejs": "^3.1.8",
         "got": "^11.8.5",
         "hpagent": "^1.0.0",
-        "minimist": "^1.2.6",
         "properties-file": "^2.1.1",
         "proxy-from-env": "^1.1.0"
       },
@@ -21,6 +21,9 @@
       "devDependencies": {
         "mocha": "^10.0.0",
         "mocha-lcov-reporter": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -309,6 +312,14 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/commander": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
+      "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -891,11 +902,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/mocha": {
       "version": "10.0.0",
@@ -1623,6 +1629,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "commander": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
+      "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2038,11 +2049,6 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
-    },
-    "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "mocha": {
       "version": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "test": "mocha -R mocha-lcov-reporter > coverage.lcov"
   },
   "dependencies": {
+    "commander": "^9.4.0",
     "ejs": "^3.1.8",
     "got": "^11.8.5",
     "hpagent": "^1.0.0",
-    "minimist": "^1.2.6",
     "properties-file": "^2.1.1",
     "proxy-from-env": "^1.1.0"
   },
@@ -23,5 +23,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "engines": {
+    "node": "^12.20.0 || >=14"
   }
 }


### PR DESCRIPTION
I am implementing a report to be used at GitHub actions.
Refactored:
- Migrated from minimist to commander.
Currently options are lower case or camelcase making error prone. Commander:
  - provides a deterministic options parse, an invalid option fails.
  - use kebab case which is the most accepted pattern.
  - positive option --no-foo -> foo: false with true by default
- Moved options parsing to the top, and split secrets/ejs options/execution options.
- Adds --ejs-file option to allow an outside ejs file.
- Adds --exit-code option so cli knows if issues are found.
- Adjust `sinceLeakPeriod` option for newer sonar, need to add a version condition.
- Adjust engines according to commander requirement.