### PR TITLE
Convert to type:module

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -10,9 +10,10 @@ jobs:
           node-version: '17'
           cache: 'npm'
       - run: npm ci
+      - run: npm link
       - run: node --check .
       - run: npm test
-      - run: node index.js
+      - run: sonar-report
           --sonarurl="https://sonarcloud.io"
           --sonarcomponent="sopra-steria:soprasteria_sonar-report"
           --sonarorganization="sopra-steria"

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 **
+!cli.js
 !index.ejs
 !index.js
 !LICENSE

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { buildCommand, generateReport } from "./index.js";
+
+generateReport(buildCommand().parse().opts());

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import { existsSync } from "fs";
 import fs from "fs/promises";
 import { resolve, dirname } from 'path';

--- a/index.js
+++ b/index.js
@@ -120,8 +120,8 @@ const generateReport = async options => {
     previousPeriod: "",
     allBugs: options.allbugs,
     fixMissingRule: options.fixMissingRule,
-    noSecurityHotspot: options.noSecurityHotspot,
-    noRulesInReport: options.noRulesInReport,
+    noSecurityHotspot: !options.securityHotspot,
+    noRulesInReport: !options.rulesInReport,
     vulnerabilityPhrase: options.vulnerabilityPhrase,
     vulnerabilityPluralPhrase: options.vulnerabilityPluralPhrase,
     // sonar URL without trailing /

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sonar-report",
-  "version": "2.7.0",
+  "version": "3.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sonar-report",
-      "version": "2.7.0",
+      "version": "3.0.1",
       "dependencies": {
         "commander": "^9.4.0",
         "ejs": "^3.1.8",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,13 @@
   "main": "index.js",
   "author": "SopraSteria",
   "bin": {
-    "sonar-report": "./index.js"
+    "sonar-report": "./cli.js"
   },
+  "exports": "./index.js",
   "scripts": {
     "test": "mocha -R mocha-lcov-reporter > coverage.lcov"
   },
+  "type": "module",
   "dependencies": {
     "commander": "^9.4.0",
     "ejs": "^3.1.8",


### PR DESCRIPTION
This is a cli only application, it's not used as a lib, so it's not a breaking change.
- Convert to a lib.
- Make ejs optional.
- Make the code more linear.
- Extract the cli run to cli.js.