### PR TITLE
feat: added optional coverage to sonar report

### DIFF
--- a/index.ejs
+++ b/index.ejs
@@ -45,6 +45,13 @@
 			<dt>Delta analysis</dt>
 			<dd><%= deltaAnalysis %></dd>
 
+			<%if (coverage) { %>
+
+			<dt>Coverage</dt>
+			<dd><%= coverage %></dd>
+
+			<% } %>
+
 			<%if (previousPeriod) { %>
 
 			<dt>Reference period </dt>


### PR DESCRIPTION
Hello,

I would like to add a simple coverage section to the sonar report. I added it optional to avoid regression for current users.