### PR TITLE
Fix: Json Report missing Rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -597,7 +597,20 @@ const generateReport = async (options) => {
   console.error(await ejs.renderFile(__dirname + "/summary.txt.ejs", data, {}));
 
   if (options.saveReportJson) {
-    await fs.writeFile(options.saveReportJson, JSON.stringify(data, null, 2));
+    const replacer = (key, value) => {
+      // JSON.stringify() not convert ES6 Map() to value, this replacer will apply for rules to add rules to json response.
+      // https://stackoverflow.com/questions/29085197/how-do-you-json-stringify-an-es6-map
+      if (key === "rules") {
+        return Array.from(value).reduce((obj, [key, value]) => {
+            obj[key] = value;
+            return obj;
+            }, {});
+      } else {
+        return value
+      }
+    }
+
+    await fs.writeFile(options.saveReportJson, JSON.stringify(data, replacer, 2));
   }
 
   if (options.ejsFile) {


### PR DESCRIPTION
**Description**
JSON Report missing rules data because ES6 Map does not work with `JSON.stringtify().`
See: [https://stackoverflow.com/questions/29085197/how-do-you-json-stringify-an-es6-map](https://stackoverflow.com/questions/29085197/how-do-you-json-stringify-an-es6-map)
Thus, the `rules` field will be empty when using JSON Report.
```JSON
  "rules": {},
```
**Solution** 
I added a simple replacer function that converts map rules into an object format using JSON.stringify()
JSON content becomes:
```JSON
{
  "rules": {
    "azureresourcemanager:S4423": {
      "name": "Weak SSL/TLS protocols should not be used",
      "htmlDesc": "...",
      "severity": "CRITICAL"
    },
  }
}
```
