### PR TITLE
fix typo query status hotspots

### DIFF
--- a/index.js
+++ b/index.js
@@ -523,7 +523,7 @@ const generateReport = async (options) => {
       do {
         try {
           const response = await got(
-            `${sonarBaseURL}/api/hotspots/search?projectKey=${sonarComponent}${filterHotspots}${newCodePeriodFilter}${withOrganization}&ps=${pageSize}&p=${page}&statuses=${HOTSPOT_STATUSES}`,
+            `${sonarBaseURL}/api/hotspots/search?projectKey=${sonarComponent}${filterHotspots}${newCodePeriodFilter}${withOrganization}&ps=${pageSize}&p=${page}&status=${HOTSPOT_STATUSES}`,
             {
               agent,
               headers,
@@ -535,7 +535,7 @@ const generateReport = async (options) => {
           data.hotspotKeys.push(...json.hotspots.map((hotspot) => hotspot.key));
         } catch (error) {
           console.error(
-            `${sonarBaseURL}/api/hotspots/search?projectKey=${sonarComponent}${filterHotspots}${newCodePeriodFilter}${withOrganization}&ps=${pageSize}&p=${page}&statuses=${HOTSPOT_STATUSES}`
+            `${sonarBaseURL}/api/hotspots/search?projectKey=${sonarComponent}${filterHotspots}${newCodePeriodFilter}${withOrganization}&ps=${pageSize}&p=${page}&status=${HOTSPOT_STATUSES}`
           );
           logError("getting hotspots list", error);
           return null;


### PR DESCRIPTION
## Description
Endpoint `apt/hotspots` uses `status` instead of `statuses` parameters to query hotspots.
See: [https://sonarqube.ow2.org/web_api/api/hotspots](https://sonarqube.ow2.org/web_api/api/hotspots)
## Solution
I changed `statuses` into `status` to ensure only query `IN_REVIEW` hotspots.