### PR TITLE
New option 'only detected rules'

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,6 +96,11 @@ const buildCommand = (command = new Command()) =>
       true
     )
     .option(
+      "--only-detected-rules",
+      "Set this flag to include only detected rules in the report. Not useful if no-rules-in-report=true.",
+      false
+    )
+    .option(
       "--vulnerability-phrase <phrase>",
       "Set to override 'Vulnerability' phrase in the report.",
       "Vulnerability"
@@ -205,6 +210,7 @@ const generateReport = async (options) => {
     fixMissingRule: options.fixMissingRule,
     noSecurityHotspot: !options.securityHotspot,
     noRulesInReport: !options.rulesInReport,
+    onlyDetectedRules: options.onlyDetectedRules,
     vulnerabilityPhrase: options.vulnerabilityPhrase,
     noCoverage: !options.coverage,
     vulnerabilityPluralPhrase: options.vulnerabilityPluralPhrase,
@@ -592,6 +598,15 @@ const generateReport = async (options) => {
       major: data.issues.filter((issue) => issue.severity === "MAJOR").length,
       minor: data.issues.filter((issue) => issue.severity === "MINOR").length,
     };
+  }
+
+  // Iterate over all rules and remove those that have no issues
+  if (!data.noRulesInReport && data.onlyDetectedRules) {
+    for (let [key, value] of data.rules) {
+      if (!data.issues.some((issue) => issue.rule === key)) {
+        data.rules.delete(key);
+      }
+    }
   }
 
   console.error(await ejs.renderFile(__dirname + "/summary.txt.ejs", data, {}));


### PR DESCRIPTION
**_Note_**: Replace PR #232 only with the requested feature

The main change is to allow users to include only the detected rules in the report, making the Known Security Rules section more compact and concise.

### Key Changes:

New Option: We have introduced a new command-line option, `--only-detected-rules`, which, when used during report generation, will include only the rules that have been detected.

### Benefits:

**Enhanced Clarity**: By including only the detected rules in the report, the Known Security Rules section will become significantly more concise. This simplifies the report and ensures that users can focus on the most critical information without unnecessary clutter.

**Improved Readability**: Users will appreciate the improved readability of the report, which will make it easier to identify and prioritize security issues.

How to Use:

To utilize this new feature, simply include the `--only-detected-rules` option when generating the report. For example:
```bash
# Generate report example
sonar-report \
  --sonarurl="https://sonarcloud.io" \
  --sonarcomponent="soprasteria_sonar-report" \
  --sonarorganization="sopra-steria" \
  --project="Sonar Report" \
  --application="sonar-report" \
  --release="1.0.0" \
  --branch="master" \
  --only-detected-rules \
  --output="samples/sonar-report_sonar-report.html"
```