### PR TITLE
fix: resolve undefined date error

### DIFF
--- a/index.js
+++ b/index.js
@@ -401,11 +401,18 @@ const generateReport = async (options) => {
       const json = JSON.parse(response.body);
 
       // get date for quality gate status, day month year format
-      data.qualityGateStatusPeriodDate = new Date(
-        json.projectStatus.period.date
-      )
-        .toISOString()
-        .substring(0, 10);
+      let qualityGateStatusPeriodDate = json.projectStatus.period?.date;
+
+      if (!qualityGateStatusPeriodDate) {
+        qualityGateStatusPeriodDate =
+          json.projectStatus.periods.length > 0
+            ? json.projectStatus.periods[0].date
+            : undefined;
+      }
+
+      data.qualityGateStatusPeriodDate = qualityGateStatusPeriodDate
+        ? new Date(qualityGateStatusPeriodDate).toISOString().substring(0, 10)
+        : undefined;
 
       if (json.projectStatus.conditions) {
         for (const condition of json.projectStatus.conditions) {


### PR DESCRIPTION
Suggestion to fix when `period` is not available but `periods` with object array

Raw error:
```
Error while getting quality gate status :  - Cannot read properties of undefined (reading 'date') -  -  - 
file:///Users/******/.nvm/versions/node/v18.17.1/lib/node_modules/sonar-report/index.js:405
        json.projectStatus.period.date
                                  ^

TypeError: Cannot read properties of undefined (reading 'date')
    at generateReport (file:///Users/******/.nvm/versions/node/v18.17.1/lib/node_modules/sonar-report/index.js:405:35)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```