### PR TITLE
Fix report generation failure with --quality-gate-status when only on…

### DIFF
--- a/index.js
+++ b/index.js
@@ -399,9 +399,17 @@ const generateReport = async (options) => {
       const json = JSON.parse(response.body);
 
       // get date for quality gate status, day month year format
-      data.qualityGateStatusPeriodDate = new Date(
-        json.projectStatus.period?.date ?? (json.projectStatus.periods.length > 0 ? json.projectStatus.periods[0].date : undefined)
-      ).toISOString().substring(0, 10);
+      let periodDate = 'N/A';
+
+      if (json.projectStatus.period) {
+        periodDate = new Date(json.projectStatus.period.date).toISOString().substring(0, 10);
+      } else if (json.projectStatus.periods && json.projectStatus.periods.length > 0) {
+        periodDate = new Date(json.projectStatus.periods[0].date).toISOString().substring(0, 10);
+      }
+
+      data.qualityGateStatusPeriodDate = periodDate;
+
+
 
       if (json.projectStatus.conditions) {
         for (const condition of json.projectStatus.conditions) {


### PR DESCRIPTION
…e analysis exists

- Resolved issue #266 where report generation fails due to missing period data in the API result.
- Added fallback mechanism to handle cases where only one analysis exists.
- Ensured that the report still generates with meaningful quality gate information.